### PR TITLE
Read JNI metadata from the renamed cuDF Spark artifact

### DIFF
--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/README.md
@@ -147,8 +147,9 @@ mvn clean package -Pudf-native-examples
 The build will automatically:
 - Extract `libcudf.so` from older rapids-4-spark jars or reconstruct it from
   the chunk-manifest representation used by newer jars
-- Read the embedded `spark-rapids-jni` and `cudf-java` version metadata from the jar
-- Download the matching `spark-rapids-jni` `cudf-pins` files
+- Read the embedded `cudf-spark-jni` and `cudf-java` version metadata from
+  the jar
+- Download the matching `cudf-spark-jni` `cudf-pins` files
 - Clone the cuDF repository at the revision recorded in the jar
 - Configure rapids-cmake with the matching `rapids-cmake` sha and package override file
 - Build only your UDF native code against the prebuilt library
@@ -165,7 +166,7 @@ library.
 
 When changing the rapids-4-spark jar version, rebuild the native UDFs with
 matching cuDF/RMM/CCCL headers and libraries. In prebuilt mode, the Maven build
-derives those native dependency pins from the `spark-rapids-jni` revision
+derives those native dependency pins from the `cudf-spark-jni` revision
 recorded in the jar. After changing jar versions, remove `target/native-deps`,
 `target/cudf-repo`, `target/cudf-pins`, and `target/cpp-build` before
 rebuilding so stale headers, pins, or libraries are not reused.

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/pom.xml
@@ -402,7 +402,7 @@
 
                                             <echo message="✓ libcudf.so extracted to: ${project.build.directory}/native-deps"/>
 
-                                            <!-- Resolve matching cuDF/RMM/CCCL pins from the spark-rapids-jni
+                                            <!-- Resolve matching cuDF/RMM/CCCL pins from the cudf-spark-jni
                                                  revision embedded in the rapids-4-spark jar. -->
                                             <chmod file="${basedir}/resolve-jni-cudf-pins.sh" perm="755"/>
                                             <exec executable="${basedir}/resolve-jni-cudf-pins.sh" failonerror="true">

--- a/examples/UDF-Examples/RAPIDS-accelerated-UDFs/resolve-jni-cudf-pins.sh
+++ b/examples/UDF-Examples/RAPIDS-accelerated-UDFs/resolve-jni-cudf-pins.sh
@@ -87,7 +87,7 @@ download_file() {
     fi
 }
 
-JNI_INFO="spark-rapids-jni-version-info.properties"
+JNI_INFO="cudf-spark-jni-version-info.properties"
 CUDF_INFO="cudf-java-version-info.properties"
 
 JNI_REVISION="$(read_property_from_jar "$JNI_INFO" revision || true)"
@@ -95,7 +95,7 @@ JNI_URL="$(read_property_from_jar "$JNI_INFO" url || true)"
 CUDF_REVISION="$(read_property_from_jar "$CUDF_INFO" revision || true)"
 
 if [ -z "$JNI_REVISION" ] || [ -z "$JNI_URL" ]; then
-    echo "ERROR: Failed to read spark-rapids-jni revision/url from $JAR_PATH" >&2
+    echo "ERROR: Failed to read cudf-spark-jni revision/url from $JAR_PATH" >&2
     echo "Expected $JNI_INFO in the jar." >&2
     exit 1
 fi
@@ -108,7 +108,7 @@ fi
 
 RAW_BASE="$(normalize_github_raw_base "$JNI_URL")"
 if [ -z "$RAW_BASE" ]; then
-    echo "ERROR: Unsupported spark-rapids-jni URL for automatic pin lookup: $JNI_URL" >&2
+    echo "ERROR: Unsupported cudf-spark-jni URL for automatic pin lookup: $JNI_URL" >&2
     echo "Only github.com URLs can be resolved automatically." >&2
     exit 1
 fi
@@ -161,14 +161,14 @@ download_file "https://raw.githubusercontent.com/rapidsai/rapids-cmake/$RAPIDS_C
 
 cat > "$PROPERTIES_FILE" <<EOF
 jar.cudf.revision=$CUDF_REVISION
-jar.spark.rapids.jni.revision=$JNI_REVISION
+jar.cudf.spark.jni.revision=$JNI_REVISION
 jar.rapids.cmake.sha=$RAPIDS_CMAKE_SHA
 jar.rapids.cmake.file=$RAPIDS_CMAKE_FILE
 jar.cudf.pins.file=$VERSIONS_FILE
 EOF
 
 echo "Resolved native dependency pins from rapids-4-spark jar:"
-echo "  spark-rapids-jni revision: $JNI_REVISION"
+echo "  cudf-spark-jni revision: $JNI_REVISION"
 echo "  cuDF revision: $CUDF_REVISION"
 echo "  rapids-cmake sha: $RAPIDS_CMAKE_SHA"
 echo "  rapids-cmake entrypoint: $RAPIDS_CMAKE_FILE"


### PR DESCRIPTION
## Summary

    Read JNI metadata from the renamed cuDF Spark artifact
    
    Update the accelerated UDF native dependency resolver to consume cudf-spark-jni-version-info.properties after the upstream JNI artifact rename.
    
    Expose the embedded JNI revision as jar.cudf.spark.jni.revision and update resolver errors, status output, Maven comments, and user documentation to use the cudf-spark-jni name. Do not retain the legacy spark-rapids-jni metadata filename or property alias.
    
    Validation: ran the native library extraction unit tests, checked resolver shell syntax, parsed the Maven POM, verified whitespace, and confirmed the changed files contain no legacy JNI references.
    
    Reference: https://github.com/NVIDIA/cudf-spark-jni/pull/5093
    Signed-off-by: Tim Liu <timl@nvidia.com>

